### PR TITLE
Additional GPU benchmark scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,14 +93,14 @@ setuptools.setup(
         'console_scripts': [
             'sbench=stencil_benchmarks.scripts.sbench:main',
             'sbench-analyze=stencil_benchmarks.scripts.sbench_analyze:main',
-            'sbench-p100-collection=stencil_benchmarks.scripts'
-            '.sbench_p100_collection:main',
             'sbench-h100-collection=stencil_benchmarks.scripts'
             '.sbench_h100_collection:main',
             'sbench-a100-collection=stencil_benchmarks.scripts'
             '.sbench_a100_collection:main',
             'sbench-v100-collection=stencil_benchmarks.scripts'
             '.sbench_v100_collection:main',
+            'sbench-p100-collection=stencil_benchmarks.scripts'
+            '.sbench_p100_collection:main',
             'sbench-mi50-collection=stencil_benchmarks.scripts'
             '.sbench_mi50_collection:main',
             'sbench-mi100-collection=stencil_benchmarks.scripts'

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,8 @@ setuptools.setup(
         'console_scripts': [
             'sbench=stencil_benchmarks.scripts.sbench:main',
             'sbench-analyze=stencil_benchmarks.scripts.sbench_analyze:main',
+            'sbench-p100-collection=stencil_benchmarks.scripts'
+            '.sbench_p100_collection:main',
             'sbench-a100-collection=stencil_benchmarks.scripts'
             '.sbench_a100_collection:main',
             'sbench-v100-collection=stencil_benchmarks.scripts'

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,8 @@ setuptools.setup(
             'sbench-analyze=stencil_benchmarks.scripts.sbench_analyze:main',
             'sbench-p100-collection=stencil_benchmarks.scripts'
             '.sbench_p100_collection:main',
+            'sbench-h100-collection=stencil_benchmarks.scripts'
+            '.sbench_h100_collection:main',
             'sbench-a100-collection=stencil_benchmarks.scripts'
             '.sbench_a100_collection:main',
             'sbench-v100-collection=stencil_benchmarks.scripts'

--- a/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/mixin.py
+++ b/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/mixin.py
@@ -74,8 +74,10 @@ class StencilMixin(Benchmark):
         self.compiler_flags = (self.default_compiler_flags() + ' ' +
                                self.compiler_flags).strip()
 
+        filename = self.template_file().partition('.')[0]
+
         try:
-            self.compiled = compilation.GnuLibrary(code, [self.compiler] +
+            self.compiled = compilation.GnuLibrary(code, filename, [self.compiler] +
                                                    self.compiler_flags.split())
         except compilation.CompilationError as error:
             raise ParameterError(*error.args) from error

--- a/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/mixin.py
+++ b/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/mixin.py
@@ -114,7 +114,8 @@ class StencilMixin(Benchmark):
                     dry_runs=self.dry_runs,
                     timers=self.timers,
                     strides=self.strides,
-                    index_type=self.index_type)
+                    index_type=self.index_type,
+                    implementation_name=self.template_file().partition('.')[0])
 
     @contextlib.contextmanager
     def on_device(self, data):

--- a/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/base.j2
+++ b/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/base.j2
@@ -55,7 +55,7 @@ using hipDeviceProp = hipDeviceProp_t;
                  }
 
 {% block gpu_kernel %}
-__global__ void gpu_kernel(
+__global__ void gpu_kernel_{{ implementation_name }}(
     {%- for arg in args %}
         {{ ctype }} * __restrict__ {{ arg }}{{ "," if not loop.last }}
     {%- endfor %}
@@ -135,7 +135,7 @@ extern "C" int kernel(
     }
 
     for (int dry_run = 0; dry_run < {{ dry_runs }}; ++dry_run) {
-        gpu_kernel<<<grid_size, block_size, smem_size>>>(
+        gpu_kernel_{{ implementation_name }}<<<grid_size, block_size, smem_size>>>(
             {%- for arg in args %}
                 {{ arg }}{{ "," if not loop.last }}
             {%- endfor %}
@@ -158,9 +158,9 @@ extern "C" int kernel(
     {%- endif %}
 
     {%- if timers == 'hip-ext' %}
-    hipExtLaunchKernelGGL(gpu_kernel, grid_size, block_size, smem_size, 0, start, stop, 0,
+    hipExtLaunchKernelGGL(gpu_kernel_{{ implementation_name }}, grid_size, block_size, smem_size, 0, start, stop, 0,
     {%- else %}
-    gpu_kernel<<<grid_size, block_size, smem_size>>>(
+    gpu_kernel_{{ implementation_name }}<<<grid_size, block_size, smem_size>>>(
     {%- endif %}
         {%- for arg in args %}
             {{ arg }}{{ "," if not loop.last }}

--- a/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/vertical_advection_classic.j2
+++ b/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/vertical_advection_classic.j2
@@ -186,7 +186,7 @@ __forceinline__ __device__ void forward_sweep(const {{ index_type }} ishift,
 }
 
 
-__global__ void __launch_bounds__({{ block_size[0] * block_size[1] }}) gpu_kernel(
+__global__ void __launch_bounds__({{ block_size[0] * block_size[1] }}) gpu_kernel_{{ implementation_name }}(
     const {{ ctype }} *__restrict__ ustage,
     const {{ ctype }} *__restrict__ upos,
     const {{ ctype }} *__restrict__ utens,

--- a/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/vertical_advection_localmem.j2
+++ b/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/vertical_advection_localmem.j2
@@ -186,7 +186,7 @@ __forceinline__ __device__ void forward_sweep(const {{ index_type }} ishift,
 }
 
 
-__global__ void __launch_bounds__({{ block_size[0] * block_size[1] }}) gpu_kernel(
+__global__ void __launch_bounds__({{ block_size[0] * block_size[1] }}) gpu_kernel_{{ implementation_name }}(
     const {{ ctype }} *__restrict__ ustage,
     const {{ ctype }} *__restrict__ upos,
     const {{ ctype }} *__restrict__ utens,

--- a/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/vertical_advection_localmemmerged.j2
+++ b/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/vertical_advection_localmemmerged.j2
@@ -389,7 +389,7 @@ __forceinline__ __device__ void forward_sweep(const {{ ctype }} *__restrict__ wc
 }
 
 
-__global__ void __launch_bounds__({{ block_size[0] * block_size[1] }}) gpu_kernel(
+__global__ void __launch_bounds__({{ block_size[0] * block_size[1] }}) gpu_kernel_{{ implementation_name }}(
     const {{ ctype }} *__restrict__ ustage,
     const {{ ctype }} *__restrict__ upos,
     const {{ ctype }} *__restrict__ utens,

--- a/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/vertical_advection_sharedmem.j2
+++ b/stencil_benchmarks/benchmarks_collection/stencils/cuda_hip/templates/vertical_advection_sharedmem.j2
@@ -194,7 +194,7 @@ __forceinline__ __device__ void forward_sweep(const {{ index_type }} ishift,
 }
 
 
-__global__ void __launch_bounds__({{ block_size[0] * block_size[1] }}) gpu_kernel(
+__global__ void __launch_bounds__({{ block_size[0] * block_size[1] }}) gpu_kernel_{{ implementation_name }}(
     const {{ ctype }} *__restrict__ ustage,
     const {{ ctype }} *__restrict__ upos,
     const {{ ctype }} *__restrict__ utens,

--- a/stencil_benchmarks/benchmarks_collection/stencils/openmp/mixin.py
+++ b/stencil_benchmarks/benchmarks_collection/stencils/openmp/mixin.py
@@ -69,7 +69,9 @@ class StencilMixin(Benchmark):
         if self.compiler.endswith('icpc'):
             os.environ['KMP_INIT_AT_FORK'] = '0'
 
-        self.compiled = compilation.GnuLibrary(code, self.compile_command())
+        filename = self.template_file().partition('.')[0]
+
+        self.compiled = compilation.GnuLibrary(code, filename, self.compile_command())
 
         if self.verify and self.dry_runs:
             warnings.warn(

--- a/stencil_benchmarks/benchmarks_collection/stream/cuda_hip.py
+++ b/stencil_benchmarks/benchmarks_collection/stream/cuda_hip.py
@@ -78,7 +78,9 @@ class Native(Benchmark):
         code = template.render(template_file, **self.template_args())
         if self.print_code:
             print(cpphelpers.format_code(code))
+        filename = 'cuda_hip'
         self.compiled = compilation.GnuLibrary(code,
+                                               filename,
                                                self.compile_command(),
                                                extension='.cu')
 

--- a/stencil_benchmarks/benchmarks_collection/stream/mc_calpin.py
+++ b/stencil_benchmarks/benchmarks_collection/stream/mc_calpin.py
@@ -67,8 +67,9 @@ class Original(Benchmark):
                     r'/\* [a-z ]*"tuned" versions of the kernels \*/(.*)',
                     cpphelpers.format_code(code),
                     re.MULTILINE | re.DOTALL).group(1))
-
+        filename = self.template_file().partition('.')[0]
         self.compiled = compilation.GnuLibrary(code,
+                                               filename,
                                                self.compile_command(),
                                                extension='.c')
 

--- a/stencil_benchmarks/scripts/sbench_a100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_a100_collection.py
@@ -51,7 +51,6 @@ common_kwargs = default_kwargs(backend='cuda',
                                gpu_architecture='sm_80',
                                verify=False,
                                dry_runs=1,
-                               gpu_timers=True,
                                alignment=128,
                                dtype='float32')
 

--- a/stencil_benchmarks/scripts/sbench_a100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_a100_collection.py
@@ -52,8 +52,7 @@ common_kwargs = default_kwargs(backend='cuda',
                                verify=False,
                                dry_runs=1,
                                alignment=128,
-                               dtype='float32',
-                               print_code=True)
+                               dtype='float32')
 
 
 @main.command()

--- a/stencil_benchmarks/scripts/sbench_a100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_a100_collection.py
@@ -52,7 +52,8 @@ common_kwargs = default_kwargs(backend='cuda',
                                verify=False,
                                dry_runs=1,
                                alignment=128,
-                               dtype='float32')
+                               dtype='float32',
+                               print_code=True)
 
 
 @main.command()

--- a/stencil_benchmarks/scripts/sbench_analyze.py
+++ b/stencil_benchmarks/scripts/sbench_analyze.py
@@ -191,10 +191,10 @@ def plot(csv, uniform, ylim, title, auto_group, group, select, filter,
 
     regexes = []
     for regex in label_regex:
-        splitter = label_regex[0]
-        if label_regex[-1] != splitter:
+        splitter = regex[0]
+        if regex[-1] != splitter:
             raise ValueError('expected input in the form /pattern/repl/')
-        pattern, repl = label_regex[1:-1].split(splitter, 1)
+        pattern, repl = regex[1:-1].split(splitter, 1)
         regexes.append((re.compile(pattern), repl))
 
     for index, row in df.iterrows():

--- a/stencil_benchmarks/scripts/sbench_h100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_h100_collection.py
@@ -1,0 +1,176 @@
+# Stencil Benchmarks
+#
+# Copyright (c) 2017-2021, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import click
+
+from stencil_benchmarks.benchmarks_collection.stencils.cuda_hip import (
+    basic, horizontal_diffusion as hdiff, vertical_advection as vadv)
+from stencil_benchmarks.tools.multirun import (Configuration,
+                                               run_scaling_benchmark,
+                                               truncate_block_size_to_domain,
+                                               default_kwargs)
+
+
+@click.group()
+def main():
+    pass
+
+
+common_kwargs = default_kwargs(backend='cuda',
+                               compiler='nvcc',
+                               gpu_architecture='sm_90',
+                               verify=False,
+                               dry_runs=1,
+                               alignment=128,
+                               dtype='float32')
+
+
+@main.command()
+@click.argument('output', type=click.Path())
+@click.option('--executions', '-e', type=int, default=101)
+@click.option('--option', '-o', multiple=True)
+def basic_bandwidth(output, executions, option):
+    kwargs = common_kwargs(
+        option,
+        loop='3D',
+        block_size=(128, 2, 1),
+        halo=(1, 1, 1),
+    )
+
+    stream_kwargs = kwargs.copy()
+    stream_kwargs.update(loop='1D', block_size=(1024, 1, 1), halo=(0, 0, 0))
+
+    configurations = [
+        Configuration(basic.Copy, name='stream', **stream_kwargs),
+        Configuration(basic.Empty, name='empty', **kwargs),
+        Configuration(basic.Copy, name='copy', **kwargs),
+        Configuration(basic.OnesidedAverage, name='avg-i', axis=0, **kwargs),
+        Configuration(basic.OnesidedAverage, name='avg-j', axis=1, **kwargs),
+        Configuration(basic.OnesidedAverage, name='avg-k', axis=2, **kwargs),
+        Configuration(basic.SymmetricAverage,
+                      name='sym-avg-i',
+                      axis=0,
+                      **kwargs),
+        Configuration(basic.SymmetricAverage,
+                      name='sym-avg-j',
+                      axis=1,
+                      **kwargs),
+        Configuration(basic.SymmetricAverage,
+                      name='sym-avg-k',
+                      axis=2,
+                      **kwargs),
+        Configuration(basic.Laplacian,
+                      name='lap-ij',
+                      along_x=True,
+                      along_y=True,
+                      along_z=False,
+                      **kwargs)
+    ]
+
+    table = run_scaling_benchmark(configurations, executions)
+    table.to_csv(output)
+
+
+@main.command()
+@click.argument('output', type=click.Path())
+@click.option('--executions', '-e', type=int, default=101)
+@click.option('--option', '-o', multiple=True)
+def horizontal_diffusion_bandwidth(output, executions, option):
+    kwargs = common_kwargs(option)
+
+    configurations = [
+        Configuration(hdiff.Classic, block_size=(32, 16, 1), **kwargs),
+        Configuration(hdiff.OnTheFly,
+                      block_size=(32, 16, 1),
+                      loop='3D',
+                      **kwargs),
+        Configuration(hdiff.OnTheFlyIncache, block_size=(32, 8, 1), **kwargs),
+        Configuration(hdiff.JScanSharedMem, block_size=(256, 32, 1), **kwargs),
+        Configuration(hdiff.JScanOtfIncache, block_size=(128, 4, 1), **kwargs),
+        Configuration(hdiff.JScanOtf, block_size=(128, 4, 1), **kwargs),
+        Configuration(hdiff.JScanShuffleIncache,
+                      block_size=(28, 8, 2),
+                      **kwargs),
+        Configuration(hdiff.JScanShuffle, block_size=(28, 8, 2), **kwargs),
+        Configuration(hdiff.JScanShuffleSystolic,
+                      block_size=(28, 4, 3),
+                      **kwargs)
+    ]
+
+    def truncate_block_size_to_domain_if_possible(**kwargs):
+        if kwargs['block_size'][0] != 28:
+            return truncate_block_size_to_domain(**kwargs)
+        return kwargs
+
+    table = run_scaling_benchmark(
+        configurations,
+        executions,
+        preprocess_args=truncate_block_size_to_domain_if_possible)
+    table.to_csv(output)
+
+
+@main.command()
+@click.argument('output', type=click.Path())
+@click.option('--executions', '-e', type=int, default=101)
+@click.option('--option', '-o', multiple=True)
+def vertical_advection_bandwidth(output, executions, option):
+    kwargs = common_kwargs(option)
+
+    configurations = [
+        Configuration(vadv.Classic,
+                      block_size=(512, 1),
+                      unroll_factor=8,
+                      **kwargs),
+        Configuration(vadv.LocalMem,
+                      block_size=(128, 1),
+                      unroll_factor=28,
+                      **kwargs),
+        Configuration(vadv.SharedMem,
+                      block_size=(64, 1),
+                      unroll_factor=0,
+                      **kwargs),
+        Configuration(vadv.LocalMemMerged,
+                      block_size=(512, 1),
+                      unroll_factor=2,
+                      **kwargs)
+    ]
+
+    table = run_scaling_benchmark(
+        configurations,
+        executions,
+        preprocess_args=truncate_block_size_to_domain)
+    table.to_csv(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/stencil_benchmarks/scripts/sbench_h100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_h100_collection.py
@@ -109,7 +109,7 @@ def horizontal_diffusion_bandwidth(output, executions, option):
     kwargs = common_kwargs(option)
 
     configurations = [
-        Configuration(hdiff.Classic, block_size=(32, 16, 1), **kwargs),
+        Configuration(hdiff.Classic, block_size=(32, 12, 1), **kwargs),
         Configuration(hdiff.OnTheFly,
                       block_size=(32, 16, 1),
                       loop='3D',
@@ -148,7 +148,7 @@ def vertical_advection_bandwidth(output, executions, option):
 
     configurations = [
         Configuration(vadv.Classic,
-                      block_size=(512, 1),
+                      block_size=(128, 1),
                       unroll_factor=8,
                       **kwargs),
         Configuration(vadv.LocalMem,
@@ -160,7 +160,7 @@ def vertical_advection_bandwidth(output, executions, option):
                       unroll_factor=0,
                       **kwargs),
         Configuration(vadv.LocalMemMerged,
-                      block_size=(512, 1),
+                      block_size=(128, 1),
                       unroll_factor=2,
                       **kwargs)
     ]

--- a/stencil_benchmarks/scripts/sbench_mi100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_mi100_collection.py
@@ -51,7 +51,6 @@ common_kwargs = default_kwargs(backend='hip',
                                gpu_architecture='gfx908',
                                verify=False,
                                dry_runs=100,
-                               gpu_timers=True,
                                alignment=512,
                                dtype='float32')
 

--- a/stencil_benchmarks/scripts/sbench_mi50_collection.py
+++ b/stencil_benchmarks/scripts/sbench_mi50_collection.py
@@ -51,7 +51,6 @@ common_kwargs = default_kwargs(backend='hip',
                                gpu_architecture='gfx906',
                                verify=False,
                                dry_runs=1,
-                               gpu_timers=True,
                                alignment=64,
                                dtype='float32')
 

--- a/stencil_benchmarks/scripts/sbench_p100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_p100_collection.py
@@ -1,0 +1,177 @@
+# Stencil Benchmarks
+#
+# Copyright (c) 2017-2021, ETH Zurich and MeteoSwiss
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import click
+
+from stencil_benchmarks.benchmarks_collection.stencils.cuda_hip import (
+    basic, horizontal_diffusion as hdiff, vertical_advection as vadv)
+from stencil_benchmarks.tools.multirun import (Configuration,
+                                               run_scaling_benchmark,
+                                               truncate_block_size_to_domain,
+                                               default_kwargs)
+
+
+@click.group()
+def main():
+    pass
+
+
+common_kwargs = default_kwargs(backend='cuda',
+                               compiler='nvcc',
+                               gpu_architecture='sm_60',
+                               verify=False,
+                               dry_runs=1,
+                               alignment=128,
+                               dtype='float32',
+                               print_code=True)
+
+
+@main.command()
+@click.argument('output', type=click.Path())
+@click.option('--executions', '-e', type=int, default=101)
+@click.option('--option', '-o', multiple=True)
+def basic_bandwidth(output, executions, option):
+    kwargs = common_kwargs(
+        option,
+        loop='3D',
+        block_size=(128, 2, 1),
+        halo=(1, 1, 1),
+    )
+
+    stream_kwargs = kwargs.copy()
+    stream_kwargs.update(loop='1D', block_size=(1024, 1, 1), halo=(0, 0, 0))
+
+    configurations = [
+        Configuration(basic.Copy, name='stream', **stream_kwargs),
+        Configuration(basic.Empty, name='empty', **kwargs),
+        Configuration(basic.Copy, name='copy', **kwargs),
+        Configuration(basic.OnesidedAverage, name='avg-i', axis=0, **kwargs),
+        Configuration(basic.OnesidedAverage, name='avg-j', axis=1, **kwargs),
+        Configuration(basic.OnesidedAverage, name='avg-k', axis=2, **kwargs),
+        Configuration(basic.SymmetricAverage,
+                      name='sym-avg-i',
+                      axis=0,
+                      **kwargs),
+        Configuration(basic.SymmetricAverage,
+                      name='sym-avg-j',
+                      axis=1,
+                      **kwargs),
+        Configuration(basic.SymmetricAverage,
+                      name='sym-avg-k',
+                      axis=2,
+                      **kwargs),
+        Configuration(basic.Laplacian,
+                      name='lap-ij',
+                      along_x=True,
+                      along_y=True,
+                      along_z=False,
+                      **kwargs)
+    ]
+
+    table = run_scaling_benchmark(configurations, executions)
+    table.to_csv(output)
+
+
+@main.command()
+@click.argument('output', type=click.Path())
+@click.option('--executions', '-e', type=int, default=101)
+@click.option('--option', '-o', multiple=True)
+def horizontal_diffusion_bandwidth(output, executions, option):
+    kwargs = common_kwargs(option)
+
+    configurations = [
+        Configuration(hdiff.Classic, block_size=(32, 16, 1), **kwargs),
+        Configuration(hdiff.OnTheFly,
+                      block_size=(32, 16, 1),
+                      loop='3D',
+                      **kwargs),
+        Configuration(hdiff.OnTheFlyIncache, block_size=(32, 8, 1), **kwargs),
+        Configuration(hdiff.JScanSharedMem, block_size=(256, 32, 1), **kwargs),
+        Configuration(hdiff.JScanOtfIncache, block_size=(128, 4, 1), **kwargs),
+        Configuration(hdiff.JScanOtf, block_size=(128, 4, 1), **kwargs),
+        Configuration(hdiff.JScanShuffleIncache,
+                      block_size=(28, 8, 2),
+                      **kwargs),
+        Configuration(hdiff.JScanShuffle, block_size=(28, 8, 2), **kwargs),
+        Configuration(hdiff.JScanShuffleSystolic,
+                      block_size=(28, 4, 3),
+                      **kwargs)
+    ]
+
+    def truncate_block_size_to_domain_if_possible(**kwargs):
+        if kwargs['block_size'][0] != 28:
+            return truncate_block_size_to_domain(**kwargs)
+        return kwargs
+
+    table = run_scaling_benchmark(
+        configurations,
+        executions,
+        preprocess_args=truncate_block_size_to_domain_if_possible)
+    table.to_csv(output)
+
+
+@main.command()
+@click.argument('output', type=click.Path())
+@click.option('--executions', '-e', type=int, default=101)
+@click.option('--option', '-o', multiple=True)
+def vertical_advection_bandwidth(output, executions, option):
+    kwargs = common_kwargs(option)
+
+    configurations = [
+        Configuration(vadv.Classic,
+                      block_size=(512, 1),
+                      unroll_factor=8,
+                      **kwargs),
+        Configuration(vadv.LocalMem,
+                      block_size=(128, 1),
+                      unroll_factor=28,
+                      **kwargs),
+        Configuration(vadv.SharedMem,
+                      block_size=(64, 1),
+                      unroll_factor=0,
+                      **kwargs),
+        Configuration(vadv.LocalMemMerged,
+                      block_size=(512, 1),
+                      unroll_factor=2,
+                      **kwargs)
+    ]
+
+    table = run_scaling_benchmark(
+        configurations,
+        executions,
+        preprocess_args=truncate_block_size_to_domain)
+    table.to_csv(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/stencil_benchmarks/scripts/sbench_v100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_v100_collection.py
@@ -51,7 +51,6 @@ common_kwargs = default_kwargs(backend='cuda',
                                gpu_architecture='sm_70',
                                verify=False,
                                dry_runs=1,
-                               gpu_timers=True,
                                alignment=128,
                                dtype='float32')
 

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -132,6 +132,7 @@ class GnuLibrary:
             # srcfile.flush()
 
             with tempfile.NamedTemporaryFile(suffix='.so') as library:
+                print([compile_command[0], '-o', library.name, srcfile.name] + compile_command[1:])
                 result = subprocess.run(
                     [compile_command[0], '-o', library.name, srcfile.name] +
                     compile_command[1:],

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -129,7 +129,7 @@ class GnuLibrary:
 
         with open("{}{}".format(filename, extension), 'w') as srcfile:
             srcfile.write(code)
-            # srcfile.flush()
+            srcfile.flush()
 
             with tempfile.NamedTemporaryFile(suffix='.so') as library:
                 print([compile_command[0], '-o', library.name, srcfile.name] + compile_command[1:])

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -129,7 +129,7 @@ class GnuLibrary:
 
         output_dir = "benchmarks_source_code"
         os.makedirs(output_dir, exist_ok=True)
-        file_path = os.path.join(output_dir, filename)
+        file_path = os.path.join(output_dir, "{}{}".format(filename, extension))
 
         with open(file_path, 'w') as srcfile:
             srcfile.write(code)

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -123,7 +123,7 @@ class GnuLibrary:
             compile_command = ['gcc'] if extension.lower() == '.c' else ['g++']
 
         if compile_command[0].endswith('nvcc'):
-            compile_command += ['-Xcompiler', '-shared', '-Xcompiler', '-fPIC']
+            compile_command += ['-Xcompiler', '-shared', '-Xcompiler', '-fPIC', '--generate-line-info']
         else:
             compile_command += ['-shared', '-fPIC']
 

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -90,6 +90,7 @@ def _capture_output(stdout: TextIO, stderr: TextIO) -> Iterator[None]:
 class GnuLibrary:
     def __init__(self,
                  code: str,
+                 filename: str,
                  compile_command: Optional[List[str]] = None,
                  extension: Optional[str] = None):
         """Compile and load a C/C++-library.
@@ -126,7 +127,7 @@ class GnuLibrary:
         else:
             compile_command += ['-shared', '-fPIC']
 
-        with tempfile.NamedTemporaryFile(suffix=extension) as srcfile:
+        with open("{}.{}".format(filename, extension)) as srcfile:
             srcfile.write(code.encode())
             srcfile.flush()
 

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -136,7 +136,6 @@ class GnuLibrary:
             srcfile.flush()
 
             with tempfile.NamedTemporaryFile(suffix='.so') as library:
-                print([compile_command[0], '-o', library.name, srcfile.name] + compile_command[1:])
                 result = subprocess.run(
                     [compile_command[0], '-o', library.name, srcfile.name] +
                     compile_command[1:],

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -128,8 +128,8 @@ class GnuLibrary:
             compile_command += ['-shared', '-fPIC']
 
         with open("{}{}".format(filename, extension), 'w') as srcfile:
-            srcfile.write(code.encode())
-            srcfile.flush()
+            srcfile.write(code)
+            # srcfile.flush()
 
             with tempfile.NamedTemporaryFile(suffix='.so') as library:
                 result = subprocess.run(

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -127,7 +127,7 @@ class GnuLibrary:
         else:
             compile_command += ['-shared', '-fPIC']
 
-        with open("{}.{}".format(filename, extension)) as srcfile:
+        with open("{}{}".format(filename, extension), 'w') as srcfile:
             srcfile.write(code.encode())
             srcfile.flush()
 

--- a/stencil_benchmarks/tools/compilation.py
+++ b/stencil_benchmarks/tools/compilation.py
@@ -90,7 +90,7 @@ def _capture_output(stdout: TextIO, stderr: TextIO) -> Iterator[None]:
 class GnuLibrary:
     def __init__(self,
                  code: str,
-                 filename: str,
+                 filename: str = 'tmp',
                  compile_command: Optional[List[str]] = None,
                  extension: Optional[str] = None):
         """Compile and load a C/C++-library.
@@ -127,7 +127,11 @@ class GnuLibrary:
         else:
             compile_command += ['-shared', '-fPIC']
 
-        with open("{}{}".format(filename, extension), 'w') as srcfile:
+        output_dir = "benchmarks_source_code"
+        os.makedirs(output_dir, exist_ok=True)
+        file_path = os.path.join(output_dir, filename)
+
+        with open(file_path, 'w') as srcfile:
             srcfile.write(code)
             srcfile.flush()
 


### PR DESCRIPTION
- Added benchmark scripts for P100 (based on the configuration of A100) and H100 GPUs
- Fixed issue with regex when using `--label-regex` with `sbench-analyze plot`
- Write each benchmark source code in `benchmarks_source_code` folder for easier inspection
- Rename GPU kernel functions to corresponding implementation name
- Removed deprecated `gpu_timers` parameter
- Added `--generate-line-info` compilation option for `nvcc` to improve source code investigation in `NSight Compute`. (To be used with `--import-source yes` in `ncu`)