### PR TITLE
Small bug fixes

### DIFF
--- a/stencil_benchmarks/scripts/sbench_a100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_a100_collection.py
@@ -51,7 +51,6 @@ common_kwargs = default_kwargs(backend='cuda',
                                gpu_architecture='sm_80',
                                verify=False,
                                dry_runs=1,
-                               gpu_timers=True,
                                alignment=128,
                                dtype='float32')
 

--- a/stencil_benchmarks/scripts/sbench_analyze.py
+++ b/stencil_benchmarks/scripts/sbench_analyze.py
@@ -191,10 +191,10 @@ def plot(csv, uniform, ylim, title, auto_group, group, select, filter,
 
     regexes = []
     for regex in label_regex:
-        splitter = label_regex[0]
-        if label_regex[-1] != splitter:
+        splitter = regex[0]
+        if regex[-1] != splitter:
             raise ValueError('expected input in the form /pattern/repl/')
-        pattern, repl = label_regex[1:-1].split(splitter, 1)
+        pattern, repl = regex[1:-1].split(splitter, 1)
         regexes.append((re.compile(pattern), repl))
 
     for index, row in df.iterrows():

--- a/stencil_benchmarks/scripts/sbench_mi100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_mi100_collection.py
@@ -51,7 +51,6 @@ common_kwargs = default_kwargs(backend='hip',
                                gpu_architecture='gfx908',
                                verify=False,
                                dry_runs=100,
-                               gpu_timers=True,
                                alignment=512,
                                dtype='float32')
 

--- a/stencil_benchmarks/scripts/sbench_mi50_collection.py
+++ b/stencil_benchmarks/scripts/sbench_mi50_collection.py
@@ -51,7 +51,6 @@ common_kwargs = default_kwargs(backend='hip',
                                gpu_architecture='gfx906',
                                verify=False,
                                dry_runs=1,
-                               gpu_timers=True,
                                alignment=64,
                                dtype='float32')
 

--- a/stencil_benchmarks/scripts/sbench_v100_collection.py
+++ b/stencil_benchmarks/scripts/sbench_v100_collection.py
@@ -51,7 +51,6 @@ common_kwargs = default_kwargs(backend='cuda',
                                gpu_architecture='sm_70',
                                verify=False,
                                dry_runs=1,
-                               gpu_timers=True,
                                alignment=128,
                                dtype='float32')
 


### PR DESCRIPTION
- Fixed issue with regex when using `--label-regex` with `sbench-analyze plot`
- Removed deprecated `gpu_timers` parameter
