### PR TITLE
Remove flake8

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --flake8 --doctest-modules --pyargs stencil_benchmarks
+addopts = --ruff --doctest-modules --pyargs stencil_benchmarks

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
-yapf
 pytest
-flake8<5 # https://github.com/tholo/pytest-flake8/issues/87
-pytest-flake8
+ruff
+pytest-ruff
 pytest-subtests


### PR DESCRIPTION
Remove flake8 due to maintenance issues (https://github.com/tholo/pytest-flake8/issues/87). Will enable ruff in a follow-up PR.